### PR TITLE
Fix contact form error message

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -33,11 +33,12 @@ $(document).ready(function () {
                     title: "Mensagem enviada com sucesso! Em breve entraremos em contato.",
                     icon: "success",
                     draggable: true
-                }); form[0].reset();
+                });
+                form[0].reset();
             },
             error: function (xhr, status, error) {
                 Swal.fire({
-                    title: "Mensagem enviada com sucesso! Em breve entraremos em contato.",
+                    title: "Ocorreu um erro ao enviar sua mensagem. Por favor, tente novamente mais tarde.",
                     icon: "error",
                     draggable: true
                 });


### PR DESCRIPTION
## Summary
- show a proper message on AJAX failure in contact form

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422832c60c83318d9436ad7fb9b7c3