### PR TITLE
Fix underline on social icons in 'Quem Somos' page

### DIFF
--- a/pages/quem-somos.php
+++ b/pages/quem-somos.php
@@ -660,6 +660,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        text-decoration: none;
         transition: all 0.3s ease;
     }
 


### PR DESCRIPTION
## Summary
- remove text underline from social media icons on the team card in *Quem Somos* page

## Testing
- `php -l pages/quem-somos.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684df00d0db0833185b671e7fae23ae7