### PR TITLE
Remove price overlay from home

### DIFF
--- a/pages/home.php
+++ b/pages/home.php
@@ -94,10 +94,6 @@
                                 <div class="brownie-overlay">
                                     <h4><?= $product['name']; ?></h4>
                                     <p><?= $product['description']; ?></p>
-                                    <div class="brownie-price">R$ <?= number_format($product['price'], 2, ',', '.'); ?></div>
-                                    <?php if (isset($product['old_price'])): ?>
-                                        <div class="brownie-old-price">R$ <?= number_format($product['old_price'], 2, ',', '.'); ?></div>
-                                    <?php endif; ?>
                                 </div>
                             </div>
                         </a>
@@ -828,13 +824,6 @@ body {
 
 .product-badge-new {
     background-color: #00a978;
-}
-
-.brownie-price {
-    font-weight: 700;
-    font-size: 1.2rem;
-    margin-top: 10px;
-    color: white;
 }
 
 .stock-warning {


### PR DESCRIPTION
## Summary
- hide price information from the home page gallery

## Testing
- `php -l pages/home.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df0f19d608331a52dfa706b25d961